### PR TITLE
Switch to Go 1.16, which is what pipelines are using & bump buildpacks API to 0.7

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/open-liberty"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/paketo-buildpacks/open-liberty
 
-go 1.17
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.4.1
@@ -10,27 +10,4 @@ require (
 	github.com/paketo-buildpacks/libjvm v1.33.0
 	github.com/paketo-buildpacks/libpak v1.57.0
 	github.com/sclevine/spec v1.4.0
-)
-
-require (
-	github.com/CycloneDX/cyclonedx-go v0.4.0 // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/VividCortex/ewma v1.1.1 // indirect
-	github.com/creack/pty v1.1.17 // indirect
-	github.com/fatih/color v1.10.0 // indirect
-	github.com/heroku/color v0.0.6 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/magiconair/properties v1.8.5 // indirect
-	github.com/mattn/go-colorable v0.1.11 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/mattn/go-runewidth v0.0.12 // indirect
-	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
-	github.com/pavel-v-chernykh/keystore-go/v4 v4.2.0 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
-	golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
## Summary

Minor adjustment to keep project in sync with other Paketo buildpack projects

## Use Cases

We are using Go 1.16 in our CI, so we should match that until we bump to Go 1.17 in Jan.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
