### PR TITLE
Include app template in packaging

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,17 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/open-liberty/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "bin/helper", "buildpack.toml"]
+  include-files = [
+    "LICENSE",
+    "NOTICE",
+    "README.md",
+    "bin/build",
+    "bin/detect",
+    "bin/main",
+    "bin/helper",
+    "buildpack.toml",
+    "templates/app.tmpl"
+  ]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Fixes #24.

Fixes an issue where the app template is not included when packaging the Open Liberty buildpack. When originally testing the feature, we were using the OL buildpack directly instead of a packaged version so we missed not including the config template.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Fixes an issue where OL apps won't build because of missing template.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
