### PR TITLE
Create config overrides directory if needed

### DIFF
--- a/helper/linker.go
+++ b/helper/linker.go
@@ -62,10 +62,12 @@ func (f FileLinker) Execute() (map[string]string, error) {
 		layerDir = "/layers/paketo-buildpacks_open-liberty/open-liberty-runtime"
 	}
 
-	if _, err := os.Stat(layerDir); os.IsNotExist(err) {
-		return map[string]string{}, fmt.Errorf("runtime root '%v' does not exist", layerDir)
+        _, err := os.Stat(layerDir)
+	if err != nil && os.IsNotExist(err) {
+		return map[string]string{}, fmt.Errorf("unable to find '%s', folder does not exist", layerDir)
+	} else if err != nil {
+	        return map[string]string{}, fmt.Errorf("unable to check %s\n%w", layerDir, err)
 	}
-
 	if err = f.Configure(layerDir, appDir); err != nil {
 		return map[string]string{}, fmt.Errorf("unable to configure\n%w", err)
 	}

--- a/helper/linker.go
+++ b/helper/linker.go
@@ -62,11 +62,11 @@ func (f FileLinker) Execute() (map[string]string, error) {
 		layerDir = "/layers/paketo-buildpacks_open-liberty/open-liberty-runtime"
 	}
 
-        _, err := os.Stat(layerDir)
+	_, err := os.Stat(layerDir)
 	if err != nil && os.IsNotExist(err) {
 		return map[string]string{}, fmt.Errorf("unable to find '%s', folder does not exist", layerDir)
 	} else if err != nil {
-	        return map[string]string{}, fmt.Errorf("unable to check %s\n%w", layerDir, err)
+		return map[string]string{}, fmt.Errorf("unable to check %s\n%w", layerDir, err)
 	}
 	if err = f.Configure(layerDir, appDir); err != nil {
 		return map[string]string{}, fmt.Errorf("unable to configure\n%w", err)

--- a/helper/linker.go
+++ b/helper/linker.go
@@ -62,7 +62,7 @@ func (f FileLinker) Execute() (map[string]string, error) {
 		layerDir = "/layers/paketo-buildpacks_open-liberty/open-liberty-runtime"
 	}
 
-	_, err := os.Stat(layerDir)
+	_, err = os.Stat(layerDir)
 	if err != nil && os.IsNotExist(err) {
 		return map[string]string{}, fmt.Errorf("unable to find '%s', folder does not exist", layerDir)
 	} else if err != nil {

--- a/helper/linker_test.go
+++ b/helper/linker_test.go
@@ -72,6 +72,8 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Setenv("BPI_OL_BASE_ROOT", baseLayerDir)).To(Succeed())
 
 			Expect(os.MkdirAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "apps"), 0755)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "configDropins", "overrides"), 0755)).To(Succeed())
+
 			Expect(os.WriteFile(filepath.Join(layerDir, "usr", "servers", "defaultServer", "server.xml"), []byte("<server/>"), 0644)).To(Succeed())
 
 			templatesDir := filepath.Join(baseLayerDir, "templates")
@@ -85,6 +87,7 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Unsetenv("BPI_OL_BASE_ROOT")).To(Succeed())
 
 			Expect(os.RemoveAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "apps"))).To(Succeed())
+			Expect(os.RemoveAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "configDropins", "overrides"))).To(Succeed())
 		})
 
 		it("works", func() {

--- a/helper/linker_test.go
+++ b/helper/linker_test.go
@@ -72,8 +72,6 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Setenv("BPI_OL_BASE_ROOT", baseLayerDir)).To(Succeed())
 
 			Expect(os.MkdirAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "apps"), 0755)).To(Succeed())
-			Expect(os.MkdirAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "configDropins", "overrides"), 0755)).To(Succeed())
-
 			Expect(os.WriteFile(filepath.Join(layerDir, "usr", "servers", "defaultServer", "server.xml"), []byte("<server/>"), 0644)).To(Succeed())
 
 			templatesDir := filepath.Join(baseLayerDir, "templates")
@@ -87,7 +85,6 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Unsetenv("BPI_OL_BASE_ROOT")).To(Succeed())
 
 			Expect(os.RemoveAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "apps"))).To(Succeed())
-			Expect(os.RemoveAll(filepath.Join(layerDir, "usr", "servers", "defaultServer", "configDropins", "overrides"))).To(Succeed())
 		})
 
 		it("works", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
Fixes #26.

## Summary
<!-- A short explanation of the proposed change -->
This change creates the <runtime-root>/usr/servers/defaultServer/configDropins/overrides directory if needed.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Fix an issue where OL 0.2.0 apps do not start up because of missing config overrides directory.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
