### PR TITLE
Ensure Java is available at build and launch

### DIFF
--- a/helper/linker.go
+++ b/helper/linker.go
@@ -99,7 +99,7 @@ func (f FileLinker) Configure(layerDir, appDir string) error {
 
 	f.Config, err = readServerConfig(configPath)
 	if err != nil {
-		return fmt.Errorf("unable to read server config: %w", err)
+		return fmt.Errorf("unable to read server config\n%w", err)
 	}
 
 	baseRoot := os.Getenv("BPI_OL_BASE_ROOT")
@@ -109,7 +109,7 @@ func (f FileLinker) Configure(layerDir, appDir string) error {
 	f.TemplatePath = filepath.Join(baseRoot, "templates")
 
 	if err = f.ContributeApp(appDir, layerDir, b); err != nil {
-		return fmt.Errorf("unable to contribute app and config to runtime root: %w", err)
+		return fmt.Errorf("unable to contribute app and config to runtime root\n%w", err)
 	}
 
 	return nil
@@ -119,7 +119,7 @@ func (f FileLinker) ContributeApp(appPath, runtimeRoot string, binding libcnb.Bi
 	linkPath := filepath.Join(runtimeRoot, "usr", "servers", "defaultServer", "apps", "app")
 	_ = os.Remove(linkPath) // we don't care if this succeeds or fails necessarily, we just want to try to remove anything in the way of the relinking
 	if err := os.Symlink(appPath, linkPath); err != nil {
-		return fmt.Errorf("unable to symlink application to '%v':\n%w", linkPath, err)
+		return fmt.Errorf("unable to symlink application to '%s'\n%w", linkPath, err)
 	}
 
 	// Skip contributing app config if already defined in the server.xml
@@ -147,23 +147,23 @@ func (f FileLinker) ContributeApp(appPath, runtimeRoot string, binding libcnb.Bi
 	templatePath := f.getConfigTemplate(binding, "app.tmpl")
 	t, err := template.New("app.tmpl").ParseFiles(templatePath)
 	if err != nil {
-		return fmt.Errorf("unable to create app template:\n%w", err)
+		return fmt.Errorf("unable to create app template\n%w", err)
 	}
 
 	configOverridesPath := filepath.Join(runtimeRoot, "usr", "servers", "defaultServer", "configDropins", "overrides")
 	if err := os.MkdirAll(configOverridesPath, 0755); err != nil {
-		return fmt.Errorf("unable to make config overrides directory:\n%w", err)
+		return fmt.Errorf("unable to make config overrides directory\n%w", err)
 	}
 
 	appConfigPath := filepath.Join(configOverridesPath, "app.xml")
 	file, err := os.Create(appConfigPath)
 	if err != nil {
-		return fmt.Errorf("unable to create file '%v':\n%w", appConfigPath, err)
+		return fmt.Errorf("unable to create file '%v'\n%w", appConfig, err)
 	}
 	defer file.Close()
 	err = t.Execute(file, appConfig)
 	if err != nil {
-		return fmt.Errorf("unable to execute template:\n%w", err)
+		return fmt.Errorf("unable to execute template\n%w", err)
 	}
 	return nil
 }
@@ -171,7 +171,7 @@ func (f FileLinker) ContributeApp(appPath, runtimeRoot string, binding libcnb.Bi
 func (f FileLinker) getConfigTemplate(binding libcnb.Binding, template string) string {
 	// Get customized template if it has been provided
 	if binding, ok := binding.SecretFilePath(template); ok {
-		f.Logger.Bodyf("Using custom template: %v", binding)
+		f.Logger.Bodyf("Using custom template: %s", binding)
 		return binding
 	}
 	// Use default config template
@@ -180,13 +180,13 @@ func (f FileLinker) getConfigTemplate(binding libcnb.Binding, template string) s
 
 func replaceFile(from, to string) error {
 	if _, err := os.Stat(from); err != nil {
-		return fmt.Errorf("unable to find file '%v'\n%w", from, err)
+		return fmt.Errorf("unable to find file '%s'\n%w", from, err)
 	}
 	if err := os.Remove(to); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("unable to delete original file '%v'\n%w", from, err)
+		return fmt.Errorf("unable to delete original file '%s'\n%w", from, err)
 	}
 	if err := os.Symlink(from, to); err != nil {
-		return fmt.Errorf("unable to symlink file from '%v' to '%v'\n%w", from, to, err)
+		return fmt.Errorf("unable to symlink file from '%s' to '%s'\n%w", from, to, err)
 	}
 	return nil
 }
@@ -194,19 +194,19 @@ func replaceFile(from, to string) error {
 func readServerConfig(configPath string) (ServerConfig, error) {
 	xmlFile, err := os.Open(configPath)
 	if err != nil {
-		return ServerConfig{}, fmt.Errorf("unable to open server.xml '%v'\n%w", configPath, err)
+		return ServerConfig{}, fmt.Errorf("unable to open server.xml '%s'\n%w", configPath, err)
 	}
 	defer xmlFile.Close()
 
 	bytes, err := ioutil.ReadAll(xmlFile)
 	if err != nil {
-		return ServerConfig{}, fmt.Errorf("unable to read server.xml '%v'\n%w", configPath, err)
+		return ServerConfig{}, fmt.Errorf("unable to read server.xml '%s'\n%w", configPath, err)
 	}
 
 	var config ServerConfig
 	err = xml.Unmarshal(bytes, &config)
 	if err != nil {
-		return ServerConfig{}, fmt.Errorf("unable to unmarshal server.xml: '%v'\n%w", configPath, err)
+		return ServerConfig{}, fmt.Errorf("unable to unmarshal server.xml: '%s'\n%w", configPath, err)
 	}
 	return config, nil
 }

--- a/openliberty/build.go
+++ b/openliberty/build.go
@@ -167,5 +167,4 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result.Layers = append(result.Layers, base)
 
 	return result, nil
-
 }

--- a/openliberty/detect.go
+++ b/openliberty/detect.go
@@ -48,7 +48,11 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				},
 
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+					{Name: PlanEntryJRE, Metadata: map[string]interface{}{
+						"launch": true,
+						"build":  true,
+						"cache":  true},
+					},
 					{Name: PlanEntryJVMApplicationPackage},
 					{Name: PlanEntryOpenLiberty},
 				},

--- a/openliberty/detect_test.go
+++ b/openliberty/detect_test.go
@@ -66,7 +66,11 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{
+							"launch": true,
+							"build":  true,
+							"cache":  true,
+						}},
 						{Name: openliberty.PlanEntryJVMApplicationPackage},
 						{Name: openliberty.PlanEntryOpenLiberty},
 					},
@@ -90,7 +94,11 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{
+							"launch": true,
+							"build":  true,
+							"cache":  true,
+						}},
 						{Name: openliberty.PlanEntryJVMApplicationPackage},
 						{Name: openliberty.PlanEntryOpenLiberty},
 					},
@@ -115,7 +123,11 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{
+							"launch": true,
+							"build":  true,
+							"cache":  true,
+						}},
 						{Name: openliberty.PlanEntryJVMApplicationPackage},
 						{Name: openliberty.PlanEntryOpenLiberty},
 					},
@@ -141,7 +153,11 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: openliberty.PlanEntryJRE, Metadata: map[string]interface{}{
+							"launch": true,
+							"build":  true,
+							"cache":  true,
+						}},
 						{Name: openliberty.PlanEntryJVMApplicationPackage},
 						{Name: openliberty.PlanEntryOpenLiberty},
 					},

--- a/openliberty/distribution.go
+++ b/openliberty/distribution.go
@@ -18,7 +18,6 @@ package openliberty
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -57,18 +56,13 @@ func (d Distribution) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to expand Liberty Runtime\n%w", err)
 		}
 
-		outErrWriter := d.Logger.InfoWriter()
-		if outErrWriter == nil {
-			outErrWriter = ioutil.Discard
-		}
-
 		executor := effect.NewExecutor()
 		if err := executor.Execute(effect.Execution{
 			Command: filepath.Join(layer.Path, "bin", "server"),
 			Args:    []string{"create", "defaultServer"},
 			Dir:     layer.Path,
-			Stdout:  outErrWriter,
-			Stderr:  outErrWriter,
+			Stdout:  bard.NewWriter(d.Logger.InfoWriter(), bard.WithIndent(3)),
+			Stderr:  bard.NewWriter(d.Logger.InfoWriter(), bard.WithIndent(3)),
 		}); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("could not create default server: %w", err)
 		}

--- a/openliberty/distribution_test.go
+++ b/openliberty/distribution_test.go
@@ -17,6 +17,7 @@
 package openliberty_test
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/paketo-buildpacks/open-liberty/openliberty"
 	"github.com/sclevine/spec"
 
@@ -57,6 +59,7 @@ func testDistribution(t *testing.T, context spec.G, it spec.S) {
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
 		distro, be := openliberty.NewDistribution(dep, dc, ctx.Application.Path)
+		distro.Logger = bard.NewLogger(io.Discard)
 		Expect(be.Name).To(Equal("open-liberty-runtime"))
 		Expect(be.Launch).To(BeTrue())
 


### PR DESCRIPTION
## Summary

- Adjusts the build plan such that Java will be installed at build and launch
- Polish some error messages and code cleanup

## Use Cases

Installing the server requires Java to be present at build time. This would happen if you built from source, but if you build and pushed compiled artifacts then Java would not be present and the buildpack would fail. This ensures that Java will be present at build time regardless.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
