### PR TITLE
Use latest version

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -40,7 +40,7 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
-    default = "21"
+    default = "*"
     description = "Which version of the Open Liberty runtime to install. Defaults to latest supported version"
     launch = false
     name = "BP_OPENLIBERTY_VERSION"


### PR DESCRIPTION
## Summary

There are nine packages available in buildpack.toml, but they are all at the same version level. I believe that previously we had tried to support multiple major versions, but this adds some complexity and scope to what we have to maintain given that it's nine packages per version level we want to support. For now, we are only supporting the most recent major version so I'm changing this default version to '*' which will pick up the latest version.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
